### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/Artifact-Virtual/arc_ecosystem/security/code-scanning/7](https://github.com/Artifact-Virtual/arc_ecosystem/security/code-scanning/7)

To address this problem, the fix is to explicitly specify the permissions for GitHub Actions jobs by adding the `permissions` key to the workflow. This can be done either at the root of the workflow file (applying to all jobs without their own explicit permissions) or at the relevant job level. Since none of the steps in this workflow appear to require write permissions (they only need to read the repository content and upload artifacts), the minimal set required is `contents: read`.

You should add the following block near the top of the workflow, after the workflow name and before the jobs section:

```yaml
permissions:
  contents: read
```

This ensures the GITHUB_TOKEN issued to jobs by this workflow will have read-only access to repository contents, which aligns with the principle of least privilege and mitigates the risk of accidental or malicious changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
